### PR TITLE
feat: add string_clone function to create deep copies

### DIFF
--- a/include/cstring.h
+++ b/include/cstring.h
@@ -36,6 +36,9 @@ typedef struct String String;
 /* Creates a String object from c-string (char *) */
 String *string_from(Arena *arena, char *str);
 
+/* Creates a deep copy of an existing String object */
+String *string_clone(Arena *arena, String *str);
+
 /* Concatinates two string objects */
 String *string_concat(Arena *arena, String *str1, String *str2);
 

--- a/lib/cstring.c
+++ b/lib/cstring.c
@@ -25,6 +25,23 @@ String *string_from(Arena *arena, char *str) {
 	return st;
 }
 
+String *string_clone(Arena *arena, String *str) {
+    String *st;
+    char *new_str;
+
+    st = (String *)arena_alloc(arena, sizeof(String));
+    
+    new_str = (char *)arena_alloc(arena, str->length + 1);
+
+    memcpy(new_str, str->str, str->length);
+    new_str[str->length] = '\0';
+
+    st->str = new_str;
+    st->length = str->length;
+
+    return st;
+}
+
 String *string_concat(Arena *arena, String *str1, String *str2) {
 	String *st;
 	char *new_str;


### PR DESCRIPTION
Implements a deep copy function that utilizes the Arena allocator to duplicate both the String struct and the underlying character buffer. Verification passed.

**Changes:**

* Added string_clone prototype to include/cstring.h.

* Implemented logic in lib/cstring.c to allocate new memory for both the String struct and the underlying character buffer.

**Verification:**

* Verified locally with a test driver.

* Confirmed deep copy behavior (cloned string has a distinct memory address from the original).

* Confirmed content integrity.

Takes care of feature #1 